### PR TITLE
Actionメニューの機能＞Export（出力）でvivliostyle.config.jsの説明を追加

### DIFF
--- a/create-and-save-documents/document-customization.md
+++ b/create-and-save-documents/document-customization.md
@@ -40,7 +40,7 @@ language: 'ja',
 
 判型はvivliostyle.comfig.jsではなく、themeで指定してください。詳細は下記をご参照ください。
 
-- [Theme（スタイル情報の選択）> Custom theme > 判型の指定](https://vivliostyle.github.io/docs-vivliostyle-pub/#/functions-of-the-actions-menu/theme#%E5%88%A4%E5%9E%8B%E3%81%AE%E6%8C%87%E5%AE%9A)
+- [Theme（スタイル情報の選択）> Custom theme > 判型の指定](/ja/functions-of-the-actions-menu/theme#%E5%88%A4%E5%9E%8B%E3%81%AE%E6%8C%87%E5%AE%9A)
 
 ## 対象となる文書の指定
 

--- a/functions-of-the-actions-menu/export.md
+++ b/functions-of-the-actions-menu/export.md
@@ -15,6 +15,7 @@ Actionメニューで「Export（出力）> PDF」を選ぶとPDFが出力され
 
 - [文書のカスタマイズ > 対象となる文書の指定](/ja/create-and-save-documents/document-customization.md#対象となる文書の指定)
 
+
 1. 「Actionメニュー > PDF」を選択します
 
 ![](images/functions-of-the-actions-menu/export/fig-1.png)

--- a/functions-of-the-actions-menu/export.md
+++ b/functions-of-the-actions-menu/export.md
@@ -2,7 +2,11 @@
 
 ## PDF
 
-Actionメニューで「Export（出力）> PDF」を選ぶとPDFが出力されます。その際、出力されるファイルは、プレビューとは無関係に`vivliostyle.config.js`の内容にもとづき処理されます。詳細は下記をご参照ください。
+Actionメニューで「Export（出力）> PDF」を選ぶとPDFが出力されます。その際、出力されるファイルは、プレビューとは無関係に`vivliostyle.config.js`の内容にもとづき処理されます。このため、もし`vivliostyle.config.js`がなければPDFは出力されません。初めてPDFを出力する際は、まず以下を参考に`vivliostyle.config.js`をルートに作成し、その中で出力するファイル名を指定してください。
+
+- [文書のカスタマイズ](/ja/create-and-save-documents/document-customization.md)
+
+関連情報として、下記もご参照ください。
 
 - [フォントの指定方法 > フォントを利用するしくみ](/ja/create-and-save-documents/how-to-specify-fonts.md#フォントを利用するしくみ)
 - [ Theme（スタイル情報の選択）> Custom theme](/ja/functions-of-the-actions-menu/theme.md#custom-theme)）
@@ -10,7 +14,6 @@ Actionメニューで「Export（出力）> PDF」を選ぶとPDFが出力され
 複数あるMarkdownファイルのうち、特定のものだけをPDF出力したい場合は、vivliostyle.config.jsで出力したいファイルだけを指定するか、出力しないファイルをコメントアウトしてください。詳細は下記をご参照ください。
 
 - [文書のカスタマイズ > 対象となる文書の指定](/ja/create-and-save-documents/document-customization.md#対象となる文書の指定)
-
 
 1. 「Actionメニュー > PDF」を選択します
 

--- a/ja/create-and-save-documents/document-customization.md
+++ b/ja/create-and-save-documents/document-customization.md
@@ -40,7 +40,7 @@ language: 'ja',
 
 判型はvivliostyle.comfig.jsではなく、themeで指定してください。詳細は下記をご参照ください。
 
-- [Theme（スタイル情報の選択）> Custom theme > 判型の指定](https://vivliostyle.github.io/docs-vivliostyle-pub/#/functions-of-the-actions-menu/theme#%E5%88%A4%E5%9E%8B%E3%81%AE%E6%8C%87%E5%AE%9A)
+- [Theme（スタイル情報の選択）> Custom theme > 判型の指定](/ja/functions-of-the-actions-menu/theme#%E5%88%A4%E5%9E%8B%E3%81%AE%E6%8C%87%E5%AE%9A)
 
 ## 対象となる文書の指定
 

--- a/ja/functions-of-the-actions-menu/export.md
+++ b/ja/functions-of-the-actions-menu/export.md
@@ -2,7 +2,11 @@
 
 ## PDF
 
-Actionメニューで「Export（出力）> PDF」を選ぶとPDFが出力されます。その際、出力されるファイルは、プレビューとは無関係に`vivliostyle.config.js`の内容にもとづき処理されます。詳細は下記をご参照ください。
+Actionメニューで「Export（出力）> PDF」を選ぶとPDFが出力されます。その際、出力されるファイルは、プレビューとは無関係に`vivliostyle.config.js`の内容にもとづき処理されます。このため、もし`vivliostyle.config.js`がなければPDFは出力されません。初めてPDFを出力する際は、まず以下を参考に`vivliostyle.config.js`をルートに作成し、その中で出力するファイル名を指定してください。
+
+- [文書のカスタマイズ](https://vivliostyle.github.io/docs-vivliostyle-pub/#/ja/create-and-save-documents/document-customization.md)
+
+関連情報として、下記もご参照ください。
 
 - [フォントの指定方法 > フォントを利用するしくみ](/ja/create-and-save-documents/how-to-specify-fonts.md#フォントを利用するしくみ)
 - [ Theme（スタイル情報の選択）> Custom theme](/ja/functions-of-the-actions-menu/theme.md#custom-theme)）

--- a/ja/functions-of-the-actions-menu/export.md
+++ b/ja/functions-of-the-actions-menu/export.md
@@ -4,7 +4,7 @@
 
 Actionメニューで「Export（出力）> PDF」を選ぶとPDFが出力されます。その際、出力されるファイルは、プレビューとは無関係に`vivliostyle.config.js`の内容にもとづき処理されます。このため、もし`vivliostyle.config.js`がなければPDFは出力されません。初めてPDFを出力する際は、まず以下を参考に`vivliostyle.config.js`をルートに作成し、その中で出力するファイル名を指定してください。
 
-- [文書のカスタマイズ](https://vivliostyle.github.io/docs-vivliostyle-pub/#/ja/create-and-save-documents/document-customization.md)
+- [文書のカスタマイズ](/ja/create-and-save-documents/document-customization.md)
 
 関連情報として、下記もご参照ください。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs-vivliostyle-pub",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
vivliostyle.config.jsがないとPDF出力ができないことを追記